### PR TITLE
fix: run sonar analysis only on main and PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,3 +29,4 @@ jobs:
     with:
       KEY: ${{ github.sha }}
       EVENT: ${{ github.event_name }}
+      REF: ${{ github.ref }}


### PR DESCRIPTION
# Description

Run sonar analysis only on main and PRs

## Type of change
- Build related changes
